### PR TITLE
fix: service name should be concat including chart-name

### DIFF
--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -30,7 +30,7 @@ Create chart name and version as used by the chart label.
 Create service name as used by the service name label.
 */}}
 {{- define "service.fullname" -}}
-{{- printf "%s-%s" .Release.Name "service" }}
+{{- printf "%s-%s-%s" .Release.Name .Chart.name "service" }}
 {{- end }}
 
 {{/*


### PR DESCRIPTION
{{/*
Create service name as used by the service name label.
*/}}
{{- define "service.fullname" -}}
{{- printf "%s-%s-%s" .Release.Name .Chart.name "service" }}
{{- end }}

| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                       |

