### PR TITLE
fix: unmatched ExportJobParameters

### DIFF
--- a/src/clients/jobManager/interfaces.ts
+++ b/src/clients/jobManager/interfaces.ts
@@ -1,5 +1,6 @@
 import { Webhook } from '@map-colonies/export-interfaces';
 import { FeatureCollection } from 'geojson';
+import { ExtendedRasterExportJobParameters } from '../../exportManager/exportManagerRaster';
 import { OperationStatus } from './enums';
 
 // This interfaces file is not relevant when unifined export implementation will be ready, this file should be deleted.
@@ -13,7 +14,7 @@ export interface ExportJobParameters {
 
 // eslint-disable-next-line import/exports-last
 export interface ExportJobResponse {
-  parameters: ExportJobParameters;
+  parameters: ExtendedRasterExportJobParameters;
   created: string;
   updated: string;
 }

--- a/src/exportManager/exportManagerRaster.ts
+++ b/src/exportManager/exportManagerRaster.ts
@@ -70,7 +70,7 @@ export class ExportManagerRaster implements IExportManager {
         const completedExportTask = res as CallbackExportResponse;
 
         const task: IExportTaskResponse<ExportJobParameters> = {
-          id: exportJob.parameters.id,
+          id: exportJob.parameters.exportId,
           catalogRecordID: completedExportTask.recordCatalogId,
           domain: Domain.RASTER,
           // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/src/tasks/models/tasksManager.ts
+++ b/src/tasks/models/tasksManager.ts
@@ -55,24 +55,25 @@ export class TasksManager {
   public async handleWebhookEvent(params: CallbackExportResponse): Promise<void> {
     const exportJob = await this.jobManagerClient.getJobById(params.jobId);
     const jobParameters = exportJob.parameters;
+    const webhook = jobParameters.exportManagementParams.webhook;
+
     const task: IExportTaskResponse<ExportJobParameters> = {
-      id: jobParameters.id,
+      id: jobParameters.exportId,
       catalogRecordID: params.recordCatalogId,
       domain: Domain.RASTER,
       // eslint-disable-next-line @typescript-eslint/naming-convention
       ROI: params.roi,
       artifactCRS: EPSGDATA[4326].code,
       description: params.description,
-      keywords: jobParameters.keywords,
+      keywords: jobParameters.exportManagementParams.keywords,
       status: convertToUnifiedTaskStatus(params.status),
       artifacts: params.artifacts as Artifact[],
-      webhook: exportJob.parameters.webhook,
+      webhook,
       createdAt: new Date(exportJob.created),
       finishedAt: new Date(exportJob.updated),
       expiredAt: params.expirationTime,
       errorReason: params.errorReason,
     };
-    const webhook = jobParameters.webhook;
     const webhookEvent: WebhookEvent<ExportJobParameters> = {
       data: task,
       event: params.status === OperationStatus.COMPLETED ? TaskEvent.TASK_COMPLETED : TaskEvent.TASK_FAILED,


### PR DESCRIPTION


| Question                | Answer                                                                          |
| ---------------- | -------------------------------------------------------------------------- |
| Bug fix         | ✔                                                                        |
| New feature     | ✖                                                                        |
| Breaking change | ✖                                                                        |
| Deprecations    | ✖                                                                        |
| Documentation   | ✖                                                                        |
| Tests added     | ✖                                                                        |
| Chore            | ✖                                                                      

use:
export type ExtendedRasterExportJobParameters = RasterExportJobParams & {
  exportId: number;
  exportManagementParams: {
    keywords?: Record<string, unknown>;
    webhook: Webhook[];
  };
};

Instead of:
export interface ExportJobParameters {
  id: number;
  keywords: Record<string, unknown>;
  webhook: Webhook[];
}



